### PR TITLE
Update 2.6.1

### DIFF
--- a/recipe/dill_0.3.6.patch
+++ b/recipe/dill_0.3.6.patch
@@ -1,0 +1,14 @@
+diff --git a/setup.py b/setup.py
+index 966129eac..0429edeff 100644
+--- a/setup.py
++++ b/setup.py
+@@ -70,7 +70,8 @@ REQUIRED_PKGS = [
+     # Minimum 6.0.0 to support wrap_array which is needed for ArrayND features
+     "pyarrow>=6.0.0",
+     # For smart caching dataset processing
+-    "dill<0.3.6",  # tmp pin until 0.3.6 release: see https://github.com/huggingface/datasets/pull/4397
++    # "dill<0.3.6",  # tmp pin until 0.3.6 release: see https://github.com/huggingface/datasets/pull/4397
++    "dill<0.3.7", # PATCH for compatibility with now releases dill 0.3.6
+     # For performance gains with apache arrow
+     "pandas",
+     # for downloading datasets over HTTPS

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,12 +58,16 @@ test:
 
 about:
   home: https://github.com/huggingface/datasets
+  summary: HuggingFace community-driven open-source library of datasets
+  description: |
+    Datasets is a lightweight library providing two main features:
+
+    - one-line dataloaders for many public datasets: one-liners to download and pre-process any of the number of datasets major public datasets (text datasets in 467 languages and dialects, image datasets, audio datasets, etc.) provided on the HuggingFace Datasets Hub. With a simple command like squad_dataset = load_dataset("squad"), get any of these datasets ready to use in a dataloader for training/evaluating a ML model (Numpy/Pandas/PyTorch/TensorFlow/JAX),
+    - efficient data pre-processing: simple, fast and reproducible data pre-processing for the above public datasets as well as your own local datasets in CSV/JSON/text/PNG/JPEG/etc. With simple commands like `processed_dataset = dataset.map(process_example)`, efficiently prepare the dataset for inspection and ML model evaluation and training.
   license: Apache-2.0
   license_family: Apache
-  # License file manually packaged. See: https://github.com/huggingface/datasets/pull/1007
-  license_file: LICENSE
-  summary: HuggingFace/Datasets is an open library of NLP datasets.
-  doc_url: https://huggingface.co/docs/datasets/
+  license_file: LICENSE  
+  doc_url: https://huggingface.co/docs/datasets/index
   dev_url: https://github.com/huggingface/datasets
 
 extra:
@@ -73,3 +77,6 @@ extra:
     - thewchan
     - mxr-conda
     - wietsedv
+  skip-lints:
+    - missing_license_url
+    - missing_doc_source_url

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,14 +20,14 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 
 requirements:
+  build:
+    - m2-patch  # [win]
+    - patch  # [not win]
   host:
     - python
     - pip
     - setuptools
     - wheel
-  build:
-    - m2-patch  # [win]
-    - patch  # [not win]
   run:
     - python
     - numpy >=1.17

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
     - dill_0.3.6.patch # dill was temporarily pinned upstream to <0.3.6 due to delay in it's release. Patch to allow 0.3.6.
 
 build:
-  skip: true  # [py<38]
+  # s390x is missing pyarrow atm 
+  skip: true  # [py<38 or s390x] 
   entry_points:
     - datasets-cli=datasets.commands.datasets_cli:main
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "datasets" %}
-{% set version = "1.12.1" %}
+{% set version = "2.6.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2f3c15323dd5358184cc73e5b11e90e1e67f30c680dfc685d04903297cc09432
+  sha256: 05d27d5966f35c2d51f5dbe07b2156cc30adc1e5c744f89947d18bb8244388ea
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 05d27d5966f35c2d51f5dbe07b2156cc30adc1e5c744f89947d18bb8244388ea
+  patches:
+    - dill_0.3.6.patch # dill was temporarily pinned upstream to <0.3.6 due to delay in it's release. Patch to allow 0.3.6.
 
 build:
   skip: true  # [py<38]
@@ -22,6 +24,9 @@ requirements:
     - pip
     - setuptools
     - wheel
+  build:
+    - m2-patch  # [win]
+    - patch  # [not win]
   run:
     - python
     - numpy >=1.17

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   # s390x is missing pyarrow atm 
-  skip: true  # [py<38 or s390x] 
+  skip: true  # [py<37 or s390x] 
   entry_points:
     - datasets-cli=datasets.commands.datasets_cli:main
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,40 +10,46 @@ source:
   sha256: 05d27d5966f35c2d51f5dbe07b2156cc30adc1e5c744f89947d18bb8244388ea
 
 build:
-  noarch: python
+  skip: true  # [py<38]
+  entry_points:
+    - datasets-cli=datasets.commands.datasets_cli:main
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - aiohttp
-    - conllu
-    - dataclasses
-    - dill
-    - fsspec
-    - huggingface_hub <0.1.0
-    - importlib_metadata
-    - lxml
-    - multiprocess
+    - python
     - numpy >=1.17
-    - openpyxl
-    - packaging
+    - pyarrow >=6.0.0
+    - dill <0.3.7
     - pandas
-    - py7zr
-    - pyarrow >=0.17.1
-    - python >=3.6
-    - python-xxhash
     - requests >=2.19.0
-    - tqdm >=4.27,<4.50.0
+    - tqdm >=4.62.1
+    - python-xxhash
+    - multiprocess
+    - importlib-metadata  # [py<38]
+    - fsspec >=2021.11.1
+    - aiohttp
+    - huggingface_hub >=0.2.0,<1.0.0
+    - packaging
+    - responses <0.19
+    - pyyaml >=5.1
 
 test:
   imports:
     - datasets
     - datasets.commands
     - datasets.utils
+  commands:
+    - pip check
+    - datasets-cli --help
+  requires:
+    - pip
 
 about:
   home: https://github.com/huggingface/datasets


### PR DESCRIPTION
# Update 2.6.1

Upstream: https://github.com/huggingface/datasets/tree/2.6.1
Jira: https://anaconda.atlassian.net/browse/PKG-681

- Update SHA and version
- Update dependencies from upstream
- Disable building for s390x until `pyarrow` is available
- Add a patch to remove a temporary upstream pinning for dill to allow for `dill 0.3.6`
    - https://github.com/huggingface/datasets/blob/2.6.1/setup.py#L73
    - The pinning is already updated on [upstream master](https://github.com/huggingface/datasets/blob/main/setup.py#L73)
