### PR TITLE
datasets 2.19.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/huggingface_hub-feedstock/pr7/bcd842d
+  - https://staging.continuum.io/prefect/fs/huggingface_hub-feedstock/pr7/ffef226

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/huggingface_hub-feedstock/pr7/ffef226

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/huggingface_hub-feedstock/pr7/bcd842d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,8 +53,7 @@ test:
     - datasets.commands
     - datasets.utils
   commands:
-    # disabling pip check due to pyarrow_hotfix not being present
-    # - pip check
+    - pip check
     - datasets-cli --help
   requires:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "datasets" %}
-{% set version = "2.12.0" %}
+{% set version = "2.19.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: faf164c18a41bea51df3f369e872f8be5b84c12ea5f6393c3896f56038af1ea3
+  sha256: 0df9ef6c5e9138cdb996a07385220109ff203c204245578b69cca905eb151d3a
 
 build:
-  # s390x is missing pyarrow atm 
-  skip: true  # [py<37 or s390x] 
+  skip: true  # [py<38]
   entry_points:
     - datasets-cli=datasets.commands.datasets_cli:main
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,10 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 0df9ef6c5e9138cdb996a07385220109ff203c204245578b69cca905eb151d3a
+  patches:
+    # removes pyarrow_hotfix as a requirement
+    # hotfix is included in pyarrow
+    - patches/0001_remove_pyarrow_hotfix.patch
 
 build:
   skip: true  # [py<38]
@@ -17,6 +21,9 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vv
 
 requirements:
+  build:
+    - patch
+    - m2patch  # [win]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,8 @@ build:
 
 requirements:
   build:
-    - patch
-    - m2-patch  # [win]
+    - patch       # [not win]
+    - m2-patch    # [win]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,12 +40,18 @@ requirements:
     - tqdm >=4.62.1
     - python-xxhash
     - multiprocess
-    - importlib-metadata  # [py<38]
     - fsspec >=2023.1.0,<=2024.3.1
     - aiohttp
     - huggingface_hub >=0.21.2
     - packaging
     - pyyaml >=5.1
+  run_constrained:
+    - apache-beam >=2.26.0
+    - tensorflow-base >=2.6.0
+    - jax >=0.3.14
+    - jaxlib >=0.3.14
+    - soundfile >=0.12.1
+    - pillow >=6.2.1
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ build:
 requirements:
   build:
     - patch
-    - m2patch  # [win]
+    - m2-patch  # [win]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,8 @@ test:
     - datasets.commands
     - datasets.utils
   commands:
-    - pip check
+    # disabling pip check due to pyarrow_hotfix not being present
+    # - pip check
     - datasets-cli --help
   requires:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,20 +24,20 @@ requirements:
     - wheel
   run:
     - python
+    - filelock
     - numpy >=1.17
-    - pyarrow >=8.0.0
-    - dill >=0.3.0,<0.3.7
+    - pyarrow >=12.0.0
+    - dill >=0.3.0,<0.3.9
     - pandas
     - requests >=2.19.0
     - tqdm >=4.62.1
     - python-xxhash
     - multiprocess
     - importlib-metadata  # [py<38]
-    - fsspec >=2021.11.1
+    - fsspec >=2023.1.0,<=2024.3.1
     - aiohttp
-    - huggingface_hub >=0.11.0,<1.0.0
+    - huggingface_hub >=0.21.2
     - packaging
-    - responses <0.19
     - pyyaml >=5.1
 
 test:

--- a/recipe/patches/0001_remove_pyarrow_hotfix.patch
+++ b/recipe/patches/0001_remove_pyarrow_hotfix.patch
@@ -1,0 +1,12 @@
+diff --git a/src/datasets/features/features.py b/src/datasets/features/features.py
+index 24948183..99080f89 100644
+--- a/src/datasets/features/features.py
++++ b/src/datasets/features/features.py
+@@ -32,7 +32,6 @@ import pandas as pd
+ import pyarrow as pa
+ import pyarrow.compute as pc
+ import pyarrow.types
+-import pyarrow_hotfix  # noqa: F401  # to fix vulnerability on pyarrow<14.0.1
+ from pandas.api.extensions import ExtensionArray as PandasExtensionArray
+ from pandas.api.extensions import ExtensionDtype as PandasExtensionDtype
+

--- a/recipe/patches/0001_remove_pyarrow_hotfix.patch
+++ b/recipe/patches/0001_remove_pyarrow_hotfix.patch
@@ -1,3 +1,24 @@
+diff --git a/setup.py b/setup.py
+index 219f6986..6d5dee76 100644
+--- a/setup.py
++++ b/setup.py
+@@ -62,7 +62,6 @@ Steps to make a release:
+      ```
+    Check that you can install it in a virtualenv/notebook by running:
+      ```
+-     pip install huggingface-hub fsspec aiohttp pyarrow-hotfix
+      pip install -U tqdm
+      pip install -i https://testpypi.python.org/pypi datasets
+      ```
+@@ -115,8 +114,6 @@ REQUIRED_PKGS = [
+     # Backend and serialization.
+     # Minimum 12.0.0 to be able to concatenate extension arrays
+     "pyarrow>=12.0.0",
+-    # As long as we allow pyarrow < 14.0.1, to fix vulnerability CVE-2023-47248
+-    "pyarrow-hotfix",
+     # For smart caching dataset processing
+     "dill>=0.3.0,<0.3.9",  # tmp pin until dill has official support for determinism see https://github.com/uqfoundation/dill/issues/19
+     # For performance gains with apache arrow
 diff --git a/src/datasets/features/features.py b/src/datasets/features/features.py
 index 24948183..99080f89 100644
 --- a/src/datasets/features/features.py
@@ -9,4 +30,4 @@ index 24948183..99080f89 100644
 -import pyarrow_hotfix  # noqa: F401  # to fix vulnerability on pyarrow<14.0.1
  from pandas.api.extensions import ExtensionArray as PandasExtensionArray
  from pandas.api.extensions import ExtensionDtype as PandasExtensionDtype
-
+ 


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4689](https://anaconda.atlassian.net/browse/PKG-4689)
- [Upstream repository](https://github.com/huggingface/datasets/tree/2.19.1)
- [Upstream changelog/diff](https://github.com/huggingface/datasets/releases)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/huggingface_hub-feedstock/pull/7

### Explanation of changes:

- Update version
- Update python version skip
- Update dependencies
- Add patch to disable the need for `pyarrow_hotfix` since we have a good version of `pyarrow` on defaults.


[PKG-4689]: https://anaconda.atlassian.net/browse/PKG-4689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ