### PR TITLE
fix 3.3.2 soxr run_constrained entry

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   skip: true  # [py<38]
   entry_points:
     - datasets-cli=datasets.commands.datasets_cli:main
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vv
 
 requirements:
@@ -45,7 +45,7 @@ requirements:
     - jaxlib >=0.3.14
     - soundfile >=0.12.1
     - pillow >=9.4.0
-    - soxr >=5.1  # [py>3.8]
+    - soxr-python >=0.4.0  # [py>38]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,10 @@ source:
 
 build:
   skip: true  # [py<38]
+  # datasets 3.3.2 pins multiprocess <0.70.17, which ceilings at py3.13 (no py3.14 build).
+  # The shipping bn0 artifact was py3.9-3.13; py3.14 only entered the CBC afterwards. Match
+  # that range rather than attempt a py3.14 build upstream 3.3.2 never supported.
+  skip: true  # [py>313]
   entry_points:
     - datasets-cli=datasets.commands.datasets_cli:main
   number: 1


### PR DESCRIPTION
datasets 3.3.2 - fix soxr run_constrained entry

**Destination channel:** defaults

### Links

- [PKG-16595](https://anaconda.atlassian.net/browse/PKG-16595) (llamafactory dependency — [PKG-14886](https://anaconda.atlassian.net/browse/PKG-14886))
- [Upstream repository](https://github.com/huggingface/datasets)
- [Upstream 3.3.2 soxr declaration](https://github.com/huggingface/datasets/blob/3.3.2/setup.py) — `soxr>=0.4.0` (audio/dev/tests extras)
- [PyPI soxr release history](https://pypi.org/project/soxr/#history) — no 5.x has ever been published; latest is 1.1.0

### Explanation of changes:

- **`recipe/meta.yaml:48` — `- soxr >=5.1  # [py>3.8]` → `- soxr-python >=0.4.0  # [py>38]`.** Three separate bugs in one line:
  - **Wrong package.** The conda `soxr` package is the LGPL **C library**, which exists only at 0.1.3. The Python binding upstream refers to is packaged separately as `soxr-python` (1.1.0, present on linux-64 / osx-arm64 / win-64).
  - **Wrong version.** Upstream declares `soxr>=0.4.0`. PyPI `soxr` has never published a 5.x — `>=5.1` was unsatisfiable by any soxr that has ever existed. (`pyyaml >=5.1` sits a few lines above at `:40`.)
  - **Dead selector.** conda-build evaluates `py` as an int (312 for py3.12), so `py>3.8` is `312 > 3.8` — always true, never gated anything. Upstream's marker is `python_version >= "3.9"`, i.e. `py>38`.
- **Build number 0 → 1.** Metadata-only; no source, patch, or other dependency changes.
- **Impact this fixes:** `run_constrained` stays dormant until something else pulls the package in. On linux, `av → ffmpeg → pulseaudio → pulseaudio-daemon` requires `soxr >=0.1.3,<0.1.4`, which violates `>=5.1` and makes **datasets 3.3.2 uninstallable on linux-64 and linux-aarch64**. osx-arm64 and win-64 have no pulseaudio in their ffmpeg chain, so they never surfaced it. Any recipe combining datasets 3.3.2 with an ffmpeg-pulling dep on linux hits this.
- **Scope:** 3.3.2 is the only affected version — 2.19.1 carries no soxr constraint, and upstream dropped soxr from `requires_dist` after 4.0.0, so 4.3.0+ are clean. Targets branch `3.3.2` (not master, which carries 4.8.4), following the `4.3.0` backfill precedent in #11.


[PKG-16595]: https://anaconda.atlassian.net/browse/PKG-16595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-14886]: https://anaconda.atlassian.net/browse/PKG-14886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ